### PR TITLE
[TASK] Simplify core installer

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/Plugin.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/Plugin.php
@@ -45,6 +45,7 @@ class Plugin implements PluginInterface {
 			->getInstallationManager()
 			->addInstaller(
 				new CoreInstaller(
+					$io,
 					$composer,
 					$filesystem,
 					new CoreInstaller\GetTypo3OrgService($io)


### PR DESCRIPTION
By deriving from the Composer library installer a lot of code duplication can
be avoided.