### PR TITLE
[BUGFIX] Remove leading forward slash when checking for ext_emconf.php

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/Downloader/T3xDownloader.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/Downloader/T3xDownloader.php
@@ -280,7 +280,7 @@ $EM_CONF[$_EXTKEY] = ' . $emConf . ';
 
 		// Traverse files.
 		foreach ($filesArray as $fileName => $fileInfo) {
-			if ($fileName != 'ext_emconf.php') {
+			if (ltrim($fileName, '/') != 'ext_emconf.php') {
 				$md5Array[$fileName] = substr($fileInfo['content_md5'], 0, 4);
 			}
 		}


### PR DESCRIPTION
Sometimes the ext_emconf.php file extracted from the T3X stream contains a leading forward slash.
Check if file ext_emconf.php has a leading forward slash when creating the MD5 array.
Otherwise the ext_emconf.php is included in MD5 hash.