### PR TITLE
Configureable installations paths and symlinks for TYPO3 source

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/BaseInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/BaseInstaller.php
@@ -1,0 +1,144 @@
+<?php
+namespace TYPO3\CMS\Composer\Installer;
+
+use Composer\Composer;
+use Composer\Installer\InstallerInterface;
+use Composer\Package\PackageInterface;
+
+abstract class BaseInstaller implements InstallerInterface {
+	protected $locations = array();
+	protected $composer;
+
+	/**
+	 * Return the install path based on package type.
+	 *
+	 * @param  PackageInterface $package
+	 * @param  string           $frameworkType
+	 *
+	 * @return string
+	 */
+	public function getInstallPath(PackageInterface $package) {
+		$type = $package->getType();
+
+		list($vendor, $name) = $this->getVendorAndPackageName($package);
+
+		$availableVars = $this->inflectPackageVars(compact('name', 'vendor', 'type'));
+
+		$extra = $package->getExtra();
+		if (!empty($extra['installer-name'])) {
+			$availableVars['name'] = $extra['installer-name'];
+		}
+
+		$templatedPath = '';
+
+		if ($this->composer->getPackage()) {
+			$extra = $this->composer->getPackage()->getExtra();
+			if (!empty($extra['installer-paths'])) {
+				$customPath = $this->mapCustomInstallPaths($extra['installer-paths'], $package->getPrettyName(), $type);
+				if ($customPath !== FALSE) {
+					$templatedPath = $this->templatePath($customPath, $availableVars);
+				}
+			}
+		}
+
+		if(empty($templatedPath)) {
+			$locations = $this->getLocations();
+			if (!isset($locations[$type])) {
+				throw new \InvalidArgumentException(sprintf('Package type "%s" is not supported', $type));
+			}
+
+			$templatedPath = $this->templatePath($locations[$type], $availableVars);
+		}
+
+		$this->filesystem->ensureDirectoryExists($templatedPath);
+
+		return realpath($templatedPath);
+	}
+
+	/**
+	 * For an installer to override to modify the vars per installer.
+	 *
+	 * @param  array $vars
+	 *
+	 * @return array
+	 */
+	public function inflectPackageVars($vars) {
+		return $vars;
+	}
+
+	/**
+	 * Gets the installer's locations
+	 *
+	 * @return array
+	 */
+	public function getLocations() {
+		return $this->locations;
+	}
+
+	/**
+	 * @param PackageInterface $package
+	 */
+	protected function getVendorAndPackageName(PackageInterface $package) {
+		$prettyName = $package->getPrettyName();
+		if (strpos($prettyName, '/') !== FALSE) {
+			list($vendor, $name) = explode('/', $prettyName);
+		} else {
+			$vendor = '';
+			$name = $prettyName;
+		}
+
+		return array($vendor, $name);
+	}
+
+	/**
+	 * Replace vars in a path
+	 *
+	 * @param  string $path
+	 * @param  array  $vars
+	 *
+	 * @return string
+	 */
+	protected function templatePath($path, array $vars = array()) {
+		if (strpos($path, '{') !== FALSE) {
+			extract($vars);
+			preg_match_all('@\{\$([A-Za-z0-9_]*)\}@i', $path, $matches);
+			if (!empty($matches[1])) {
+				foreach ($matches[1] as $var) {
+					$path = str_replace('{$' . $var . '}', $$var, $path);
+				}
+			}
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Search through a passed paths array for a custom install path.
+	 *
+	 * @param  array  $paths
+	 * @param  string $name
+	 * @param  string $type
+	 *
+	 * @return string
+	 */
+	protected function mapCustomInstallPaths(array $paths, $name, $type) {
+		foreach ($paths as $path => $names) {
+			if (in_array($name, $names) || in_array('type:' . $type, $names)) {
+				return $path;
+			}
+		}
+
+		return FALSE;
+	}
+
+	/**
+	 * Returns if this installer can install that package type
+	 *
+	 * @param string $packageType
+	 *
+	 * @return boolean
+	 */
+	public function supports($packageType) {
+		return array_key_exists($packageType, $this->locations);
+	}
+}

--- a/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
@@ -95,16 +95,6 @@ class CoreInstaller extends BaseInstaller {
 	}
 
 	/**
-	 * Returns if this installer can install that package type
-	 *
-	 * @param string $packageType
-	 * @return boolean
-	 */
-	public function supports($packageType) {
-		return $packageType === 'typo3-cms-core';
-	}
-
-	/**
 	 * Checks that provided package is installed.
 	 *
 	 * @param \Composer\Repository\InstalledRepositoryInterface $repo repository in which to check
@@ -182,17 +172,6 @@ class CoreInstaller extends BaseInstaller {
 
 		$this->removeCode($package);
 		$repo->removePackage($package);
-	}
-
-	/**
-	 * Returns the installation path of a package
-	 *
-	 * @param  \Composer\Package\PackageInterface $package
-	 * @return string
-	 */
-	public function getInstallPath(\Composer\Package\PackageInterface $package) {
-		$this->filesystem->ensureDirectoryExists(self::TYPO3_SRC_DIR);
-		return realpath(self::TYPO3_SRC_DIR);
 	}
 
 	/**

--- a/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
@@ -116,7 +116,7 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 
 		$this->installCode($package);
 
-		$this->filesystem->establishSymlinks($this->symlinks);
+		$this->filesystem->establishSymlinks($this->symlinks, TRUE);
 
 		if (!$repo->hasPackage($package)) {
 			$repo->addPackage(clone $package);
@@ -140,7 +140,7 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 
 		$this->updateCode($initial, $target);
 
-		$this->filesystem->establishSymlinks($this->symlinks);
+		$this->filesystem->establishSymlinks($this->symlinks, TRUE);
 
 		$repo->removePackage($initial);
 		if (!$repo->hasPackage($target)) {

--- a/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
@@ -32,12 +32,26 @@ use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
  * @author Christian Opitz <christian.opitz at netresearch.de>
  * @author Thomas Maroschik <tmaroschik@dfau.de>
  */
-class CoreInstaller implements \Composer\Installer\InstallerInterface {
+class CoreInstaller extends BaseInstaller {
 
-	const TYPO3_SRC_DIR		= 'typo3_src';
-	const TYPO3_DIR			= 'typo3';
-	const TYPO3_INDEX_PHP	= 'index.php';
+	const TYPO3_SRC_DIR = 'typo3_src';
+	const TYPO3_DIR = 'typo3';
+	const TYPO3_INDEX_PHP = 'index.php';
 
+	/**
+	 * Install locations for packages by type
+	 *
+	 * @var array
+	 */
+	protected $locations = array(
+		'typo3-cms-core' => self::TYPO3_SRC_DIR
+	);
+
+	/**
+	 * Symlink to create
+	 *
+	 * @var array
+	 */
 	protected $symlinks = array();
 
 	/**
@@ -69,12 +83,15 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 		$this->downloadManager = $composer->getDownloadManager();
 		$this->filesystem = $filesystem;
 		$this->getTypo3OrgService = $getTypo3OrgService;
-		$this->symlinks = array(
-			self::TYPO3_SRC_DIR . DIRECTORY_SEPARATOR . self::TYPO3_INDEX_PHP
-				=> self::TYPO3_INDEX_PHP,
-			self::TYPO3_SRC_DIR . DIRECTORY_SEPARATOR . self::TYPO3_DIR
-				=> self::TYPO3_DIR
-		);
+		$extra = $this->composer->getPackage()->getExtra();
+		if(!isset($extra['typo3-core-symlinks'])) {
+			$this->symlinks = array(
+				self::TYPO3_SRC_DIR . DIRECTORY_SEPARATOR . self::TYPO3_INDEX_PHP => self::TYPO3_INDEX_PHP,
+				self::TYPO3_SRC_DIR . DIRECTORY_SEPARATOR . self::TYPO3_DIR => self::TYPO3_DIR
+			);
+		} elseif(is_array($extra['typo3-core-symlinks']) && !empty($extra['typo3-core-symlinks'])) {
+			$this->symlinks = $extra['typo3-core-symlinks'];
+		}
 	}
 
 	/**

--- a/Classes/TYPO3/CMS/Composer/Plugin/Util/Filesystem.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Util/Filesystem.php
@@ -48,9 +48,9 @@ class Filesystem extends \Composer\Util\Filesystem {
 	/**
 	 *
 	 */
-	public function establishSymlinks(array $links) {
+	public function establishSymlinks(array $links, $makeRelative = FALSE) {
 		foreach ($links as $source => $target) {
-			$this->symlink($source, $target);
+			$this->symlink($source, $target, TRUE, $makeRelative);
 		}
 	}
 
@@ -70,6 +70,15 @@ class Filesystem extends \Composer\Util\Filesystem {
 	 * @param bool $makeRelative Create a relative link instead of an absolute
 	 */
 	public function symlink($source, $target, $copyOnFailure = TRUE, $makeRelative = FALSE) {
+		$targetDirectory = dirname($target);
+		$this->ensureDirectoryExists($targetDirectory);
+		if(!$this->isAbsolutePath($targetDirectory)) {
+			$target = realpath($targetDirectory).DIRECTORY_SEPARATOR.basename($target);
+		}
+		if(!$this->isAbsolutePath($source)) {
+			$source = realpath($targetDirectory.DIRECTORY_SEPARATOR.$source);
+		}
+
 		if (!file_exists($source)) {
 			throw new \InvalidArgumentException('The symlink source "' . $source . '" is not available.');
 		}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "minimum-stability": "dev",
     "replace": {
         "lw/typo3cms-installers": "*",
-        "netresearch/composer-installers": "*"
+        "netresearch/composer-installers": "*",
+        "typo3/cms-composer-installers": "*"
     },
     "require": {
         "composer-plugin-api": "^1.0.0"


### PR DESCRIPTION
I wanted to support distribution structures where the TYPO3 core is not in the document root but a level above, like /typo3_src, with "/" being the distribution root, containing the composer.json. The document root would be /www-data and the extension would be located in /www-data/typo3conf/ext. The symlinks for index.php and typo3 would be located in the document root pointing a level up, e.g. "../typo3_src/index.php".

Therefore I improved the relative symlink functionality in the FileSystem utility (first commit [e48c91c]) and then improved the installers to use it (second commit [7e54c60]). Afterwards I improved the installers to make the installations paths configureable via the "extra" section in the composer.json, like in the composer/installers package (third commit [6cdc299]).