### PR TITLE
[BUGFIX] Prevent copy on symlink failure

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
@@ -140,7 +140,7 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 
 		$this->installCode($package);
 
-		$this->filesystem->establishSymlinks($this->symlinks);
+		$this->filesystem->establishSymlinks($this->symlinks, FALSE);
 
 		if (!$repo->hasPackage($package)) {
 			$repo->addPackage(clone $package);
@@ -164,7 +164,7 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 
 		$this->updateCode($initial, $target);
 
-		$this->filesystem->establishSymlinks($this->symlinks);
+		$this->filesystem->establishSymlinks($this->symlinks, FALSE);
 
 		$repo->removePackage($initial);
 		if (!$repo->hasPackage($target)) {


### PR DESCRIPTION
This patch prevents the copy of source files and folders to the target
direction as a simple copy isn't enough to be able to run TYPO3.