### PR TITLE
[TASK] Add error information for Windows systems

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Plugin/Util/Filesystem.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Util/Filesystem.php
@@ -82,20 +82,24 @@ class Filesystem extends \Composer\Util\Filesystem {
 		$symlinkSource = strtr($makeRelative ? $this->findShortestPath($target, $source) : $source, '/', DIRECTORY_SEPARATOR);
 		$symlinkTarget = strtr($target, '/', DIRECTORY_SEPARATOR);
 		$symlinkSuccessfull = @symlink($symlinkSource, $symlinkTarget);
+		$additionalErrorInformation = '';
 		if (!$symlinkSuccessfull && !stristr(PHP_OS, 'darwin') && !stristr(PHP_OS, 'cygwin') && stristr(PHP_OS, 'win')) {
 			// Try fallback to mklink for Windows, because symlink can't handle relative paths starting with "..\"
 			$output = NULL;
 			$parameter = is_dir($source) ? ' /D' : '';
 			$processExecutor = new \Composer\Util\ProcessExecutor();
 			$symlinkSuccessfull = $processExecutor->execute('mklink' . $parameter . ' ' . escapeshellarg($symlinkTarget) . ' ' . escapeshellarg($symlinkSource), $output) === 0;
+			if (!$symlinkSuccessfull) {
+				$additionalErrorInformation = PHP_EOL . ' ' . PHP_EOL . 'Windows system detected - please ensure you are running the Composer command with administrator rights to be able to create symlinks.';
+			}
 		}
 		if (!$symlinkSuccessfull && !$copyOnFailure) {
-			throw new \RuntimeException('Symlinking target "' . $symlinkTarget . '" to source "' . $symlinkSource . '" ("' . $source . '")  failed.', 1430494084);
+			throw new \RuntimeException('Symlinking target "' . $symlinkTarget . '" to source "' . $symlinkSource . '" ("' . $source . '")  failed.' . $additionalErrorInformation, 1430494084);
 		} elseif (!$symlinkSuccessfull && $copyOnFailure) {
 			try {
 				$this->copy($symlinkSource, $symlinkTarget);
 			} catch (\Exception $exception) {
-				throw new \RuntimeException('Neiter symlinking nor copying target "' . $symlinkTarget . '" to source "' . $symlinkSource . '" ("' . $source . '") worked.', 1430494090);
+				throw new \RuntimeException('Neither symlinking nor copying target "' . $symlinkTarget . '" to source "' . $symlinkSource . '" ("' . $source . '") worked.' . $additionalErrorInformation, 1430494090);
 			}
 		}
 	}


### PR DESCRIPTION
This patch adds an error information for Windows systems if creating
a symlink failed. This might be because of missing administrator rights.