### PR TITLE
Add conflict to composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "require": {
         "composer-plugin-api": "^1.0.0"
     },
+    "conflict": {
+        "composer/installers": "*"
+    }
     "require-dev": {
         "composer/composer": "1.*"
     },


### PR DESCRIPTION
composer/installers has an incomplete implementation
for installing typo3-cms-extension type packages.

To avoid hard to debug issues, avoid installation of both packages.