### PR TITLE
[BUGFIX] Fix t3x download with empty conflicts

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/Downloader/T3xDownloader.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/Downloader/T3xDownloader.php
@@ -375,7 +375,7 @@ $EM_CONF[$_EXTKEY] = ' . $emConf . ';
 			if (isset($dependency[$type]['typo3'])) {
 				unset($dependency[$type]['typo3']);
 			}
-			$dependencyString = count($dependency[$type]) ? implode(',', array_keys($dependency[$type])) : '';
+			$dependencyString = !empty($dependency[$type]) ? implode(',', array_keys($dependency[$type])) : '';
 			return $dependencyString;
 		}
 		return '';


### PR DESCRIPTION
The "conflicts" of an extension may be an empty string instead of an empty array which must be taken into account. This fixes the following error:

```
[ErrorException]
  array_keys() expects parameter 1 to be array, string given
```