### PR TITLE
Dev mode configuration, skip symlinks and extension directory options

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/CoreInstaller.php
@@ -83,6 +83,10 @@ class CoreInstaller implements \Composer\Installer\InstallerInterface {
 	 * Initialize symlinks with configuration
 	 */
 	protected function initializeSymlinks() {
+		if ($this->pluginConfig->get('skip-symlinks') === true) {
+			return;
+		}
+
 		$webDir = $this->filesystem->normalizePath($this->pluginConfig->get('web-dir'));
 		$this->filesystem->ensureDirectoryExists($webDir);
 		$backendDir = $this->filesystem->normalizePath($this->pluginConfig->get('backend-dir'));

--- a/Classes/TYPO3/CMS/Composer/Installer/ExtensionInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/ExtensionInstaller.php
@@ -34,8 +34,6 @@ use TYPO3\CMS\Composer\Plugin\Config;
  */
 class ExtensionInstaller implements \Composer\Installer\InstallerInterface {
 
-	const TYPO3_EXT_DIR = 'ext';
-
 	/**
 	 * @var string
 	 */
@@ -85,8 +83,7 @@ class ExtensionInstaller implements \Composer\Installer\InstallerInterface {
 	 * Initialize the extension dir based on configuration
 	 */
 	protected function initializeExtensionDir() {
-		$configDir = $this->filesystem->normalizePath($this->pluginConfig->get('config-dir'));
-		$this->extensionDir = $configDir . DIRECTORY_SEPARATOR . self::TYPO3_EXT_DIR;
+		$this->extensionDir = $this->filesystem->normalizePath($this->pluginConfig->get('ext-dir'));
 	}
 
 	/**
@@ -170,6 +167,10 @@ class ExtensionInstaller implements \Composer\Installer\InstallerInterface {
 	 * @return string           path
 	 */
 	public function getInstallPath(PackageInterface $package) {
+		if ($this->pluginConfig->get('use-ext-dir') === FALSE) {
+			return $this->filesystem->normalizePath($this->pluginConfig->get('vendor-dir')) . DIRECTORY_SEPARATOR . $package->getName();
+		}
+
 		$extensionKey = '';
 		foreach ($package->getReplaces() as $packageName => $version) {
 			if (strpos($packageName, '/') === FALSE) {

--- a/Classes/TYPO3/CMS/Composer/Plugin/Config.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Config.php
@@ -175,7 +175,7 @@ class Config {
 				? 'typo3/cms-dev'
 				: 'typo3/cms';
 
-			if (is_array($rootPackageExtraConfig)) {
+			if (is_array($rootPackageExtraConfig) && isset($rootPackageExtraConfig[$extrasKey])) {
 				$config->merge($rootPackageExtraConfig[$extrasKey]);
 			}
 

--- a/Classes/TYPO3/CMS/Composer/Plugin/Config.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Config.php
@@ -48,8 +48,8 @@ class Config {
 	 */
 	public function merge(array $config) {
 		// Override defaults with given config
-		if (!empty($config['typo3/cms']) && is_array($config['typo3/cms'])) {
-			foreach ($config['typo3/cms'] as $key => $val) {
+		if (!empty($config) && is_array($config)) {
+			foreach ($config as $key => $val) {
 				$this->config[$key] = $val;
 			}
 		}
@@ -167,16 +167,16 @@ class Config {
 			$baseDir = static::extractBaseDir($composer->getConfig());
 			$config = new static($baseDir);
 			$rootPackageExtraConfig = $composer->getPackage()->getExtra();
+
+			$extrasKey = !in_array('--no-dev', $_SERVER['argv']) && isset($rootPackageExtraConfig['typo3/cms-dev'])
+				? 'typo3/cms-dev'
+				: 'typo3/cms';
+
 			if (is_array($rootPackageExtraConfig)) {
-				$config->merge($rootPackageExtraConfig);
+				$config->merge($rootPackageExtraConfig[$extrasKey]);
 			}
-			$config->merge(
-				array(
-					'typo3/cms' => array(
-						'vendor-dir' => $composer->getConfig()->get('vendor-dir')
-					)
-				)
-			);
+
+			$config->merge(array('vendor-dir' => $composer->getConfig()->get('vendor-dir')));
 		}
 		return $config;
 	}

--- a/Classes/TYPO3/CMS/Composer/Plugin/Config.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Config.php
@@ -15,9 +15,11 @@ class Config {
 		'web-dir' => '.',
 		'backend-dir' => '{$web-dir}/typo3',
 		'config-dir' => '{$web-dir}/typo3conf',
+		'ext-dir' => '{$config-dir}/ext',
 		'temporary-dir' => '{$web-dir}/typo3temp',
 		'cache-dir' => '{$temporary-dir}/Cache',
 		'cms-package-dir' => 'typo3_src',
+		'use-ext-dir' => true,
 		'skip-symlinks' => false,
 		'composer-mode' => true,
 	);

--- a/Classes/TYPO3/CMS/Composer/Plugin/Config.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Config.php
@@ -18,6 +18,7 @@ class Config {
 		'temporary-dir' => '{$web-dir}/typo3temp',
 		'cache-dir' => '{$temporary-dir}/Cache',
 		'cms-package-dir' => 'typo3_src',
+		'skip-symlinks' => false,
 		'composer-mode' => true,
 	);
 


### PR DESCRIPTION
Relates to #21 and #38 

Unfortunately I couldn't reproduce #35 on OSX. 

    "extra": {
        "typo3/cms": {
            "cms-package-dir": "{$vendor-dir}/typo3/cms",
            "web-dir": "web"
        },
        "typo3/cms-dev": {
            "cms-package-dir": "{$vendor-dir}/typo3/cms",
            "use-ext-dir": false,
            "skip-symlinks": true
        }
    },

_Both configurations can of course take all options._

* If the typo3/cms-dev section exists, it's used as long as --no-dev is not present in the argument list. 
* When --no-dev is present, the "typo3/cms" section is used instead. 
* If the typo3/cms-dev section does not exist, typo3/cms is always used. Regardless of --no-dev.

If "use-ext-dir" is set to false, the extensions are installed in {$vendor-dir}/typo3-ter/*