### PR TITLE
Option to install extensions under vendor directory

### DIFF
--- a/Classes/TYPO3/CMS/Composer/Installer/ExtensionInstaller.php
+++ b/Classes/TYPO3/CMS/Composer/Installer/ExtensionInstaller.php
@@ -170,6 +170,10 @@ class ExtensionInstaller implements \Composer\Installer\InstallerInterface {
 	 * @return string           path
 	 */
 	public function getInstallPath(PackageInterface $package) {
+		if ($this->pluginConfig->get('use-ext-dir') === false) {
+			return $this->filesystem->normalizePath($this->pluginConfig->get('vendor-dir')) . DIRECTORY_SEPARATOR . $package->getName();
+		}
+
 		$extensionKey = '';
 		foreach ($package->getReplaces() as $packageName => $version) {
 			if (strpos($packageName, '/') === FALSE) {

--- a/Classes/TYPO3/CMS/Composer/Plugin/Config.php
+++ b/Classes/TYPO3/CMS/Composer/Plugin/Config.php
@@ -18,6 +18,7 @@ class Config {
 		'temporary-dir' => '{$web-dir}/typo3temp',
 		'cache-dir' => '{$temporary-dir}/Cache',
 		'cms-package-dir' => 'typo3_src',
+		'use-ext-dir' => true,
 		'composer-mode' => true,
 	);
 


### PR DESCRIPTION
To install all typo3-ter extensions under vendor/typo3-ter instead of the default typo3conf/ext

    "extra": {
        "typo3/cms": {
            "use-ext-dir": false
        }
    }

