### PR TITLE
[TASK] Sanitize invalid ext_emconf.php constraints

### DIFF
--- a/src/Installer/Downloader/T3xDownloader.php
+++ b/src/Installer/Downloader/T3xDownloader.php
@@ -346,6 +346,17 @@ $EM_CONF[$_EXTKEY] = ' . $emConf . ';
             $emConf['conflicts'] = $this->dependencyToString($emConf['constraints'], 'conflicts');
         }
 
+        foreach (array('depends', 'conflicts', 'suggests') as $constraint) {
+            if (empty($emConf['constraints'][$constraint])) {
+                continue;
+            }
+            foreach (array_keys($emConf['constraints'][$constraint]) as $constraintKey) {
+                if (empty($constraintKey)) {
+                    unset($emConf['constraints'][$constraint][$constraintKey]);
+                }
+            }
+        }
+
         // Remove TER v1-style entries
         unset($emConf['dependencies']);
         unset($emConf['conflicts']);


### PR DESCRIPTION
It might happen that downloaded T3X files contain invalid constraints
sections having empty key/value assignments which lead to exceptions
when the extension finally shall be activated in TYPO3.

To circumvent that, the T3xDownloader::fixEmConf() is extended by the
functionality to remove those invalid constraints.

Resolves: #63