### PR TITLE
[BUGFIX] PHP 7.2 compatibility in T3xDownloader::download

### DIFF
--- a/src/Installer/Downloader/T3xDownloader.php
+++ b/src/Installer/Downloader/T3xDownloader.php
@@ -34,7 +34,7 @@ class T3xDownloader extends ArchiveDownloader implements ChangeReportInterface
     /**
      * {@inheritDoc}
      */
-    public function download(PackageInterface $package, $path)
+    public function download(PackageInterface $package, $path, $output = true)
     {
         // set package so we can use it in the extract method
         $this->package = $package;


### PR DESCRIPTION
Method signature must be compatible with parent:
download(Composer\Package\PackageInterface $package, $path, $output = true)