### PR TITLE
[BUGFIX] Fix replace section parsing in ExtensionKeyResolver

### DIFF
--- a/src/Plugin/Util/ExtensionKeyResolver.php
+++ b/src/Plugin/Util/ExtensionKeyResolver.php
@@ -34,9 +34,9 @@ class ExtensionKeyResolver
         if (strpos($package->getType(), 'typo3-cms-') === false) {
             throw new \RuntimeException(sprintf('Tried to resolve an extension key from non extension package "%s"', $package->getName()), 1501195043);
         }
-        foreach ($package->getReplaces() as $packageName => $version) {
-            if (strpos($packageName, '/') === false) {
-                $extensionKey = trim($packageName);
+        foreach ($package->getReplaces() as $link) {
+            if (strpos($link->getTarget(), '/') === false) {
+                $extensionKey = trim($link->getTarget());
                 break;
             }
         }


### PR DESCRIPTION
We can not assume that PackageInterface::getReplaces() always
returns an array with string based keys:
1. the documentation says it returns Link[]
2. composer actually adds auto generated replaces entries using
integer keys (due to using array push) when it resolves `self.version`.

We do now refactor the code to use the Link object to retrieve
the real replacement target. (an alternative would be to add another
early return using `if (is_string($packageName)) continue;`, but
using $link->getTarget() should be a much cleaner approach. Composer
1.0.0 also type hinted getReplaces() to return Link[] so this change
should be safe to work with composer versions in the wild.

This bug does only happen when the early break in the foreach loop does
not match. That happens when a replace section is defined but does not
container an entry without a slash.
Extensions will start to remove extension names from `replaces`,
as composer showns a warning when using package names without '/' in it:

  Deprecation warning: replace.ext_key is invalid, it should have a vendor
  name, a forward slash, and a package name.
  The vendor and package name can be words separated by -, . or _.
  The complete name should match
  "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*".
  Make sure you fix this as Composer 2.0 will error.

Fixes: #80