### PR TITLE
[TASK] Add vendor-dir environment variable

### DIFF
--- a/res/php/autoload-include.tmpl.php
+++ b/res/php/autoload-include.tmpl.php
@@ -3,6 +3,10 @@ if (!getenv('TYPO3_PATH_COMPOSER_ROOT')) {
     putenv('TYPO3_PATH_COMPOSER_ROOT=' . '{$base-dir}');
     $_ENV['TYPO3_PATH_COMPOSER_ROOT'] = '{$base-dir}';
 }
+if (!getenv('TYPO3_PATH_VENDOR')) {
+    putenv('TYPO3_PATH_VENDOR=' . '{$vendor-dir}');
+    $_ENV['TYPO3_PATH_VENDOR'] = '{$vendor-dir}';
+}
 if (!getenv('TYPO3_PATH_APP')) {
     putenv('TYPO3_PATH_APP=' . '{$app-dir}');
     $_ENV['TYPO3_PATH_APP'] = '{$app-dir}';

--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -46,11 +46,18 @@ class Config
     protected $baseDir;
 
     /**
-     * @param string $baseDir
+     * @var string
      */
-    public function __construct($baseDir = null)
+    protected $vendorDir;
+
+    /**
+     * @param string $baseDir
+     * @param string $vendorDir
+     */
+    public function __construct(string $baseDir, string $vendorDir)
     {
         $this->baseDir = $baseDir;
+        $this->vendorDir = $vendorDir;
         // load defaults
         $this->config = static::$defaultConfig;
     }
@@ -85,6 +92,8 @@ class Config
             case 'app-dir':
                 $val = rtrim($this->process($this->config[$key], $flags), '/\\');
                 return ($flags & self::RELATIVE_PATHS === 1) ? $val : $this->realpath($val);
+            case 'vendor-dir':
+                return ($flags & self::RELATIVE_PATHS === 1) ? $this->vendorDir : $this->realpath($this->vendorDir);
             case 'base-dir':
                 return ($flags & self::RELATIVE_PATHS === 1) ? '' : $this->realpath($this->baseDir);
             default:
@@ -191,12 +200,13 @@ class Config
         static $config;
         if ($config === null) {
             $baseDir = static::extractBaseDir($composer->getConfig());
+            $vendorDir = $composer->getConfig()->get('vendor-dir');
             if ($composer->getPackage()->getName() === 'typo3/cms') {
                 // Configuration for the web dir is different, in case
                 // typo3/cms is the root package
                 self::$defaultConfig['web-dir'] = '.';
             }
-            $config = new static($baseDir);
+            $config = new static($baseDir, $vendorDir);
             $rootPackageExtraConfig = $composer->getPackage()->getExtra();
             if (is_array($rootPackageExtraConfig)) {
                 $config->merge($rootPackageExtraConfig);

--- a/src/Plugin/Core/IncludeFile/VendorDirToken.php
+++ b/src/Plugin/Core/IncludeFile/VendorDirToken.php
@@ -1,0 +1,78 @@
+<?php
+namespace TYPO3\CMS\Composer\Plugin\Core\IncludeFile;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Composer\IO\IOInterface;
+use Composer\Util\Filesystem;
+use TYPO3\CMS\Composer\Plugin\Config as Typo3PluginConfig;
+
+class VendorDirToken implements TokenInterface
+{
+    /**
+     * @var string
+     */
+    private $name = 'vendor-dir';
+
+    /**
+     * @var Typo3PluginConfig
+     */
+    private $typo3PluginConfig;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var IOInterface
+     */
+    private $io;
+
+    /**
+     * VendorDirToken constructor.
+     *
+     * @param IOInterface $io
+     * @param Typo3PluginConfig $typo3PluginConfig
+     * @param Filesystem $filesystem
+     */
+    public function __construct(IOInterface $io, Typo3PluginConfig $typo3PluginConfig, Filesystem $filesystem = null)
+    {
+        $this->io = $io;
+        $this->typo3PluginConfig = $typo3PluginConfig;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     * @return string
+     */
+    public function getContent()
+    {
+        $includeFileFolder = dirname(__DIR__, 5);
+        return $this->filesystem->findShortestPathCode(
+            $includeFileFolder,
+            $this->typo3PluginConfig->get('vendor-dir'),
+            true
+        );
+    }
+}

--- a/src/Plugin/PluginImplementation.php
+++ b/src/Plugin/PluginImplementation.php
@@ -26,6 +26,7 @@ use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\AppDirToken;
 use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\BaseDirToken;
 use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\ComposerModeToken;
 use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\RootDirToken;
+use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\VendorDirToken;
 use TYPO3\CMS\Composer\Plugin\Core\IncludeFile\WebDirToken;
 use TYPO3\CMS\Composer\Plugin\Core\ScriptDispatcher;
 use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
@@ -72,6 +73,7 @@ class PluginImplementation
                 $this->composer,
                 [
                     new BaseDirToken($io, $pluginConfig),
+                    new VendorDirToken($io, $pluginConfig),
                     new AppDirToken($io, $pluginConfig),
                     new WebDirToken($io, $pluginConfig),
                     new RootDirToken($io, $pluginConfig),


### PR DESCRIPTION
To be exposed as TYPO3_PATH_VENDOR.

## Usecase
For DI configuration we would like to be able to determine the filesystem path to a composer package installed in the vendor folder.
See following WIP/POC patch https://review.typo3.org/c/Packages/TYPO3.CMS/+/58255/58/typo3/sysext/fluid/Configuration/Services.yaml#18 for an example where the TYPO3 fluid sysext would need to define composer path dependent configurations for the composer package `typo3fluid/fluid` (in this case to be explictly picked up for DI service configuration).
There will (probably) be other usecases, so this environment variable (with proper fallback handling for classic mode – `$sitePath . '/typo3/vendor'`) would be exposed as API in TYPO3 core: `\TYPO3\CMS\Core\Core\Environment::getVendorPath()`.

## Motivation
…for adding this to CmsComposerInstallers:
The vendor dir could theoretically be computed runtime, but that would be very ugly. See:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/58255/58/typo3/sysext/core/Classes/DependencyInjection/ContainerBuilder.php#165