### PR TITLE
Allow PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "netresearch/composer-installers": "*"
     },
     "require": {
-        "php": ">=7.0.0 <7.4",
+        "php": ">=7.0.0 <=7.4",
         "composer-plugin-api": "^1.0.0"
     },
     "conflict": {


### PR DESCRIPTION
As PHP 7.4 is now in the RC phase it would be nice that this package also supports that version. E.g. travis tests on own extensions fail on 7.4snapshot because the dependency is not met.