### PR TITLE
[TASK] Allow PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,10 @@ jobs:
             fail-fast: false
             matrix:
                 php-versions:
-                    - "7.0"
-                    - "7.1"
                     - "7.2"
                     - "7.3"
                     - "7.4"
+                    - "8.0"
                 composer-versions:
                     - "v1"
                     - "v2"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "composer/composer": "1.2.*@dev || 2.0.*@dev",
         "overtrue/phplint": "^2.0",
-        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.5"
+        "phpunit/phpunit": "^8.5"
     },
     "conflict": {
         "composer/installers": "<1.0.24 || >1.0.24"

--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,13 @@
         "netresearch/composer-installers": "*"
     },
     "require": {
-        "php": ">=7.0.0 <7.5",
+        "php": "^7.2 || ^8.0",
         "composer-plugin-api": "^1.0.0 || ^2.0.0"
     },
     "require-dev": {
         "composer/composer": "1.2.*@dev || 2.0.*@dev",
         "overtrue/phplint": "^2.0",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.5"
     },
     "conflict": {
         "composer/installers": "<1.0.24 || >1.0.24"

--- a/tests/Installer/InstallerTestCase.php
+++ b/tests/Installer/InstallerTestCase.php
@@ -62,7 +62,7 @@ class InstallerTestCase extends TestCase
      */
     protected $io;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->previousDirectory = getcwd();
         $this->rootDirectory = TestCase::getUniqueTmpDirectory();
@@ -87,7 +87,7 @@ class InstallerTestCase extends TestCase
         $this->io = $this->createMock(IOInterface::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         chdir($this->previousDirectory);
         if (is_dir($this->rootDirectory)) {


### PR DESCRIPTION
* Allow a PHP 8 capable phpnunit
  composer req --dev phpunit/phpunit:"^6.5 || ^7.5 || ^8.5"

* Allow PHP 8 and drop 7.0 and 7.1
  composer req php:"^7.2 || ^8.0"

* Test case method signature adaption for PHP 8 compat.
  This requires to drop PHP 7.0 since :void has been
  introduced with PHP 7.1.