### PR TITLE
[BUGFIX] Remove multiple warnings for same missing extension key

### DIFF
--- a/src/Plugin/Util/ExtensionKeyResolver.php
+++ b/src/Plugin/Util/ExtensionKeyResolver.php
@@ -54,7 +54,7 @@ The TYPO3 extension package "${packageName}", does not define an extension key i
 MESSAGE;
             $io->writeError(sprintf('<comment>%s</comment>', $message));
 
-            self::$packagesShownExtKeyWarning[]= $package->getName();
+            self::$packagesShownExtKeyWarning[] = $package->getName();
         }
         foreach ($package->getReplaces() as $link) {
             if (strpos($link->getTarget(), '/') === false) {

--- a/src/Plugin/Util/ExtensionKeyResolver.php
+++ b/src/Plugin/Util/ExtensionKeyResolver.php
@@ -24,6 +24,9 @@ use Composer\Package\PackageInterface;
  */
 class ExtensionKeyResolver
 {
+    /** @var string[] */
+    protected static $packagesShownExtKeyWarning = [];
+
     /**
      * Resolves the extension key from replaces or package name
      *
@@ -41,12 +44,17 @@ class ExtensionKeyResolver
         if (!empty($extra['typo3/cms']['extension-key'])) {
             return $extra['typo3/cms']['extension-key'];
         }
-        if ($io instanceof IOInterface) {
+        if (
+            $io instanceof IOInterface
+            && !in_array($package->getName(), self::$packagesShownExtKeyWarning, true)
+        ) {
             $packageName = $package->getName();
             $message = <<<MESSAGE
 The TYPO3 extension package "${packageName}", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
 MESSAGE;
             $io->writeError(sprintf('<comment>%s</comment>', $message));
+
+            self::$packagesShownExtKeyWarning[]= $package->getName();
         }
         foreach ($package->getReplaces() as $link) {
             if (strpos($link->getTarget(), '/') === false) {

--- a/src/Plugin/Util/ExtensionKeyResolver.php
+++ b/src/Plugin/Util/ExtensionKeyResolver.php
@@ -40,12 +40,12 @@ class ExtensionKeyResolver
         if (strpos($package->getType(), 'typo3-cms-') === false) {
             throw new \RuntimeException(sprintf('Tried to resolve an extension key from non extension package "%s"', $package->getName()), 1501195043);
         }
-        
+
         $packageName = $package->getName();
         if (self::$extensionKeyByPackage[$packageName] ?? false) {
             return self::$extensionKeyByPackageCache[$packageName];
         }
-        
+
         $extra = $package->getExtra();
         if (!empty($extra['typo3/cms']['extension-key'])) {
             return $extra['typo3/cms']['extension-key'];
@@ -69,7 +69,7 @@ MESSAGE;
         if (!empty($extra['installer-name'])) {
             $extensionKey = $extra['installer-name'];
         }
-        
+
         self::$extensionKeyByPackageCache[$packageName] = $extensionKey;
 
         return $extensionKey;


### PR DESCRIPTION
Currently, there would be unnecessary many warnings for the same extension due to 
\TYPO3\CMS\Composer\Installer\ExtensionInstaller::getInstallPath() being called during several composer passes.

This simply adds a static member that keeps track of for which packages a warning has already been shown.

Fixes #114