### PR TITLE
Extend plugin to generate PackageStates.php and ActiveExtensions.php

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
             - name: Setup PHP version and composer
               uses: shivammathur/setup-php@v2
+              env:
+                  COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   php-version: ${{ matrix.php-versions }}
                   tools: composer:${{ matrix.composer-versions }}, php-cs-fixer
@@ -41,6 +43,10 @@ jobs:
               if: ${{ matrix.composer-versions == 'v2' }}
               run: composer require "composer/composer:^2.0" --dev --no-update
 
+            - name: Setup TYPO3
+              if: ${{ matrix.composer-versions == 'v2' && matrix.php-versions == '7.4' || matrix.composer-versions == 'v2' && matrix.php-versions == '8.0' }}
+              run: ./tests/setup-testing.sh
+
             - name: Install composer dependencies
               run: composer install
 
@@ -55,3 +61,7 @@ jobs:
 
             - name: Unit Tests
               run: composer test:php:unit
+
+            - name: Unit Tests Packages Files
+              if: ${{ matrix.composer-versions == 'v2' && matrix.php-versions == '7.4' || matrix.composer-versions == 'v2' && matrix.php-versions == '8.0' }}
+              run: composer test:php:unit tests/Plugin/ActiveExtensionsTest.php tests/Plugin/PackageStatesTest.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,8 @@
     <testsuites>
         <testsuite name="installer-unit-tests">
             <directory>tests</directory>
+            <exclude>./tests/Plugin/ActiveExtensionsTest.php</exclude>
+            <exclude>./tests/Plugin/PackageStatesTest.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/Installer/Plugin.php
+++ b/src/Installer/Plugin.php
@@ -23,6 +23,7 @@ use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use TYPO3\CMS\Composer\Plugin\Config;
 use TYPO3\CMS\Composer\Plugin\PluginImplementation;
+use TYPO3\CMS\Composer\Plugin\Util\ComposerPackageManager;
 
 /**
  * The plugin that registers the installers (registered by extra key in composer.json)
@@ -117,6 +118,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 break;
             case ScriptEvents::POST_AUTOLOAD_DUMP:
                 $this->pluginImplementation->postAutoloadDump();
+                $this->generatePackageFiles($event);
                 break;
         }
     }
@@ -138,5 +140,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $io->writeError('<error>TYPO3 installers plugin will be disabled!</error>');
             throw new \RuntimeException('TYPO3 Installer disabled!', 1469105842);
         }
+    }
+
+    /**
+     *  @param Event $event The Composer event.
+     */
+    public function generatePackageFiles(Event $event)
+    {
+        $event->getIO()->write('Write PackageStates.php/ActiveExtensions.php ...');
+        $packageManager = new ComposerPackageManager($event);
+        $packageManager->initialize();
     }
 }

--- a/src/Plugin/Util/ComposerPackageManager.php
+++ b/src/Plugin/Util/ComposerPackageManager.php
@@ -1,0 +1,249 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\Composer\Plugin\Util;
+
+use Composer\Composer;
+use Composer\Factory;
+use Composer\InstalledVersions;
+use Composer\Script\Event;
+use TYPO3\CMS\Composer\Plugin\Config;
+
+class ComposerPackageManager
+{
+    /**
+     * Raw data of installed packages, see InstalledVersions.php
+     */
+    protected $raw;
+
+    /**
+     * Array of extensions and their requirements
+     */
+    protected $required = [];
+
+    /**
+     * Array of typo3 extensions with their package name
+     */
+    protected $extensionPackageNames = [];
+
+    /**
+     * Mapping for from extension key to composer package name
+     */
+    protected $extensionPackageNameMap = [];
+
+    /**
+     * @var Event
+     */
+    protected $event;
+
+    /**
+     * @var Composer
+     */
+    protected $composer;
+
+    public function __construct(Event $event)
+    {
+        $this->raw = InstalledVersions::getRawData();
+        $this->event = $event;
+        $this->composer = $event->getComposer();
+    }
+
+    public function initialize()
+    {
+        $this->filterByType('/^typo3-cms-framework/');
+        $orderFrameworkPackages = $this->orderDependencies();
+
+        $this->filterByType('/^typo3-cms-extension/');
+        $orderExtensionPackages = $this->orderDependencies();
+
+        $this->writePackageStates(array_merge($orderFrameworkPackages, $orderExtensionPackages));
+        $this->writeActiveExtensions(array_merge($orderFrameworkPackages, $orderExtensionPackages));
+    }
+
+    /**
+     * Get all packages by type using a regex
+     *
+     * @param string $regex
+     */
+    public function filterByType(string $regex): void
+    {
+        $this->extensionPackageNames = [];
+        $this->required = [];
+
+        foreach ($this->composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+            if (preg_match($regex, $package->getType(), $output_array)) {
+                $thisRequire = [];
+
+                foreach ($package->getRequires() as $require) {
+                    $thisRequire[] = $require->getTarget();
+                }
+
+                $extensions[] = $package->getName();
+                $this->extensionPackageNameMap[$package->getName()] = $package->getExtra()['typo3/cms']['extension-key'] ?? basename($this->raw['versions'][$package->getName()]['install_path']);
+                $this->required[$package->getName()] = $thisRequire;
+            }
+        }
+
+        // TODO: Why are package names duplicated ??
+        $this->extensionPackageNames = array_values(array_unique($extensions ?? []));
+    }
+
+    /**
+     * Order extensions based on the required section of composer.json
+     *
+     * @return array
+     */
+    private function orderDependencies(): array
+    {
+        foreach ($this->required as $key => $extension) {
+            $rePosition = $originalKey = array_search($key, $this->extensionPackageNames);
+
+            foreach ($extension as $required) {
+                if ($positionOfRequire = array_search($required, $this->extensionPackageNames)) {
+                    if ($rePosition < $positionOfRequire) {
+                        $rePosition = $positionOfRequire;
+                    }
+                }
+            }
+
+            unset($this->extensionPackageNames[$originalKey]);
+            array_splice($this->extensionPackageNames, $rePosition, 0, $key);
+        }
+        return $this->extensionPackageNames;
+    }
+
+    /**
+     * Add packagePath to PackageStates array
+     *
+     * @param array $extensions
+     * @return array
+     */
+    private function appendPackagePath(array $extensions): array
+    {
+        $packageStates = [];
+        $root = dirname(realpath(Factory::getComposerFile()));
+        foreach ($extensions as $extension) {
+            $path = $this->raw['versions'][$extension]['install_path'] ?? '';
+            $relativePackagePath = str_replace($root, '..', $path);
+            preg_match('/typo3conf\/ext.*|typo3\/sysext.*/', $relativePackagePath, $extensionPath);
+
+            try {
+                $packageStates[$this->extensionPackageNameMap[$extension]]['packagePath'] = $extensionPath[0];
+            } catch (\ErrorException $e) {
+                throw new \ErrorException('No "install_path" set in InstalledVersions.php, can\'t generate PackageStates.php/ActiveExtensions.php. Make sure you are running composer >= 2.1');
+            }
+        }
+
+        return $packageStates;
+    }
+
+    /**
+     * Write php File named PackageStates.php
+     * Takes a array of packages names to be written
+     *
+     * @param array $extensions
+     */
+    private function writePackageStates(array $extensions): void
+    {
+        $packageStatesContent = [
+            'packages' => $this->appendPackagePath($extensions),
+            'version' => 5,
+        ];
+
+        $comment = "
+/**
+ * Sorted array of TYPO3 extensions 'split' into two main groups
+ *   1. typo3-cms-framework
+ *   2. typo3-cms-extension
+ */
+        ";
+
+        $vendorDir = $this->composer->getConfig()->get('vendor-dir');
+        $pluginConfig = Config::load($this->composer);
+        $packageStatesFile = $pluginConfig->get('web-dir') . DIRECTORY_SEPARATOR . 'typo3conf/PackageStates.php';
+
+        file_put_contents(
+            $packageStatesFile,
+            sprintf("<?php\n%s\nreturn %s;", $comment, var_export($packageStatesContent, true))
+        );
+    }
+
+    private function writeActiveExtensions(array $extensions): void
+    {
+        $pluginConfig = Config::load($this->composer);
+        $packageBasePath = $pluginConfig->get('web-dir') . DIRECTORY_SEPARATOR;
+        $extensions = $this->appendPackagePath($extensions);
+        $activeExtensions = [];
+
+        foreach ($extensions as $key => $extension) {
+            $packageName = array_search($key, $this->extensionPackageNameMap);
+            $activeExtensions[$key] = [
+                'composerPackage' => $packageName,
+                'version' => InstalledVersions::getVersion($packageName),
+                'path' => $packageBasePath . $extension['packagePath'],
+            ];
+        }
+
+        $activeExtensionsFile = $this->composer->getConfig()->get('vendor-dir') . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'ActiveExtensions.php';
+        $comment = <<<EOF
+// This file was autogenerated using typo3/cms-composer-installers
+// 'composer dump-autoload' will recreate this file
+EOF;
+
+        $extensions = 'private static array $extensions = ' . var_export($activeExtensions, true);
+        $activeExtensionsContent = <<<EOF
+<?php
+
+namespace TYPO3\CMS\Core\Package;
+
+$comment
+
+class ActiveExtensions {
+    $extensions;
+
+    public static function getRawData() {
+        return self::\$extensions;
+    }
+
+    public static function getInfo(\$extensionKey) {
+        return self::\$extensions[\$extensionKey] ?: null;
+    }
+
+    public static function getExtensionKey(\$packageName) {
+        \$key = array_search(\$packageName, array_column(self::\$extensions, 'composerPackage'));
+        return \$key === false ? null : array_keys(self::\$extensions)[\$key];
+    }
+
+    public static function getName(\$extensionKey) {
+        return self::\$extensions[\$extensionKey]['composerPackage'] ?: null;
+    }
+
+    public static function getVersion(\$extensionKey) {
+        return self::\$extensions[\$extensionKey]['version'] ?: null;
+    }
+
+    public static function getPath(\$extensionKey) {
+        return self::\$extensions[\$extensionKey]['path'] ?: null;
+    }
+}
+EOF;
+
+        file_put_contents(
+            $activeExtensionsFile,
+            $activeExtensionsContent
+        );
+    }
+}

--- a/tests/Plugin/ActiveExtensionsTest.php
+++ b/tests/Plugin/ActiveExtensionsTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class ActiveExtensionsTest extends TestCase
+{
+    const TYPO3_PATH = '/tmp/typo3-cms-installer/';
+
+    public function setUp(): void
+    {
+        include_once self::TYPO3_PATH . 'vendor/composer/ActiveExtensions.php';
+        parent::setUp();
+    }
+
+    public function testGetName(): void
+    {
+        $name = \TYPO3\CMS\Core\Package\ActiveExtensions::getName('core');
+        self::assertSame('typo3/cms-core', $name);
+    }
+
+    public function testGetExtensionKey(): void
+    {
+        $extKey = \TYPO3\CMS\Core\Package\ActiveExtensions::getExtensionKey('typo3/cms-core');
+        self::assertSame('core', $extKey);
+
+        $extKey = \TYPO3\CMS\Core\Package\ActiveExtensions::getExtensionKey('georgringer/news');
+        self::assertSame('news', $extKey);
+    }
+
+    public function testGetPath(): void
+    {
+        $path = \TYPO3\CMS\Core\Package\ActiveExtensions::getPath('core');
+        self::assertFileExists($path);
+
+        $path = \TYPO3\CMS\Core\Package\ActiveExtensions::getPath('news');
+        self::assertFileExists($path);
+    }
+
+    public function testGetVersion(): void
+    {
+        $regex = '/^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?$/';
+        $version = \TYPO3\CMS\Core\Package\ActiveExtensions::getVersion('core');
+        $match = preg_match($regex, $version);
+        self::assertNotEmpty($match);
+
+        $version = \TYPO3\CMS\Core\Package\ActiveExtensions::getVersion('news');
+        $match = preg_match($regex, $version);
+        self::assertNotEmpty($match);
+    }
+}

--- a/tests/Plugin/PackageStatesTest.php
+++ b/tests/Plugin/PackageStatesTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class PackageStatesTest extends TestCase
+{
+    const TYPO3_PATH = '/tmp/typo3-cms-installer/';
+
+    public function testPackageStatesArray(): void
+    {
+        $packageStates = self::TYPO3_PATH . 'public/typo3conf/PackageStates.php';
+        self::assertFileExists($packageStates);
+        $packageStatesArray = require $packageStates;
+        self::assertSame($this->packageStatesArraySample(), $packageStatesArray);
+    }
+
+    private function packageStatesArraySample(): array
+    {
+        return [
+            'packages' => [
+                'core' => [
+                    'packagePath' => 'typo3/sysext/core',
+                ],
+                'beuser' => [
+                    'packagePath' => 'typo3/sysext/beuser',
+                ],
+                'belog' => [
+                    'packagePath' => 'typo3/sysext/belog',
+                ],
+                'extbase' => [
+                    'packagePath' => 'typo3/sysext/extbase',
+                ],
+                'extensionmanager' => [
+                    'packagePath' => 'typo3/sysext/extensionmanager',
+                ],
+                'felogin' => [
+                    'packagePath' => 'typo3/sysext/felogin',
+                ],
+                'filelist' => [
+                    'packagePath' => 'typo3/sysext/filelist',
+                ],
+                'fluid' => [
+                    'packagePath' => 'typo3/sysext/fluid',
+                ],
+                'form' => [
+                    'packagePath' => 'typo3/sysext/form',
+                ],
+                'frontend' => [
+                    'packagePath' => 'typo3/sysext/frontend',
+                ],
+                'fluid_styled_content' => [
+                    'packagePath' => 'typo3/sysext/fluid_styled_content',
+                ],
+                'impexp' => [
+                    'packagePath' => 'typo3/sysext/impexp',
+                ],
+                'info' => [
+                    'packagePath' => 'typo3/sysext/info',
+                ],
+                'install' => [
+                    'packagePath' => 'typo3/sysext/install',
+                ],
+                'recordlist' => [
+                    'packagePath' => 'typo3/sysext/recordlist',
+                ],
+                'backend' => [
+                    'packagePath' => 'typo3/sysext/backend',
+                ],
+                'dashboard' => [
+                    'packagePath' => 'typo3/sysext/dashboard',
+                ],
+                'rte_ckeditor' => [
+                    'packagePath' => 'typo3/sysext/rte_ckeditor',
+                ],
+                'seo' => [
+                    'packagePath' => 'typo3/sysext/seo',
+                ],
+                'setup' => [
+                    'packagePath' => 'typo3/sysext/setup',
+                ],
+                'sys_note' => [
+                    'packagePath' => 'typo3/sysext/sys_note',
+                ],
+                't3editor' => [
+                    'packagePath' => 'typo3/sysext/t3editor',
+                ],
+                'tstemplate' => [
+                    'packagePath' => 'typo3/sysext/tstemplate',
+                ],
+                'viewpage' => [
+                    'packagePath' => 'typo3/sysext/viewpage',
+                ],
+                'news' => [
+                    'packagePath' => 'typo3conf/ext/news',
+                ],
+            ],
+            'version' => 5,
+        ];
+    }
+}

--- a/tests/setup-testing.sh
+++ b/tests/setup-testing.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Script is used to setup a TYPO3 for testing under /tmp/typo3-cms-installer
+SCRIPT_PATH=$PWD/`dirname "${BASH_SOURCE[0]}"`
+TYPO3_FOLDER=/tmp/typo3-cms-installer
+
+[ -d "$TYPO3_FOLDER" ] && rm -Rf $TYPO3_FOLDER
+composer create-project typo3/cms-base-distribution $TYPO3_FOLDER || exit 1
+cd $TYPO3_FOLDER
+composer config repositories.local path "$SCRIPT_PATH/../"
+composer config repositories.composer vcs git@github.com:ochorocho/composer.git
+composer config minimum-stability dev
+# Require
+composer req --prefer-source composer/composer:dev-improve-installed-versions-9648 || exit 1
+composer req georgringer/news:^11 || exit 1
+# Running local composer here to generate required files until MR was merged, see https://github.com/composer/composer/pull/9699
+./vendor/bin/composer install --prefer-source --no-plugins
+./vendor/bin/composer update --prefer-source typo3/cms-composer-installers && ./vendor/bin/composer dump-autoload
+cd $PWD


### PR DESCRIPTION
This extends the plugin to collect all typo3 extensions and creates `typo3conf/PackageStates.php` file.
In addition the class ActiveExtensions is created and stored in `vendor/composer/ActiveExtensions.php`

ActiveExtensions.php contains methods to interact with all TYPO3 packages:

* getExtensionKey($packageName)
* getVersion($extensionKey)
* getPath($extensionKey)
* getInfo($extensionKey)

⚠️This does not cover non-composer mode!

⚠️ Requires following PR to be merged
https://github.com/composer/composer/pull/9699

 see `tests/setup-testing.sh` for setup details

PackageStatesTest.php, ActiveExtensionsTest.php run only on PHP 7.4 and 8.0 with composer 2