### PR TITLE
[BUGFIX] Disable Composer package handling for extension testing

### DIFF
--- a/src/Plugin/PluginImplementation.php
+++ b/src/Plugin/PluginImplementation.php
@@ -64,17 +64,21 @@ class PluginImplementation
         $pluginConfig = PluginConfig::load($this->composer, $io);
 
         $this->scriptDispatcher = $scriptDispatcher ?: new ScriptDispatcher($event);
+        $includeFileTokens = [
+            new BaseDirToken($io, $pluginConfig),
+            new AppDirToken($io, $pluginConfig),
+            new WebDirToken($io, $pluginConfig),
+            new RootDirToken($io, $pluginConfig),
+        ];
+        // Disable Composer package management when testing testing extensions as the testing framework operates in non Composer mode
+        if ($this->composer->getPackage()->getType() !== 'typo3-cms-extension' || strpos((getenv('TYPO3_CONTEXT') ?: 'Production'), 'ExtensionTesting') === false) {
+            $includeFileTokens[] = new ComposerModeToken($io, $pluginConfig);
+        }
         $this->includeFile = $includeFile
             ?: new IncludeFile(
                 $io,
                 $this->composer,
-                [
-                    new BaseDirToken($io, $pluginConfig),
-                    new AppDirToken($io, $pluginConfig),
-                    new WebDirToken($io, $pluginConfig),
-                    new RootDirToken($io, $pluginConfig),
-                    new ComposerModeToken($io, $pluginConfig),
-                ],
+                $includeFileTokens,
                 $fileSystem
             );
     }


### PR DESCRIPTION
The testing framework creates new TYPO3 instances for
functional tests, which operate as classic non Composer
TYPO3 installation. Therefore we enable all handling
for such instances accordingly. Older TYPO3 versions
worked fine mostly without this special handling, because the
only effective difference was class loading, which worked
fine as the autoload.php was included, which made all classes
available. However even for these versions, some edge cases
could occur with some test extensions, where non Composer
handling would have been required.

To not break existing CI, a special Application Context
is introduced. When testing extensions with TYPO3 11,
the environment variable TYPO3_CONTEXT
MUST contain the string "ExtensionTesting".
This means you must set the application context to something like:
"Production/ExtensionTesting", "Development/ExtensionTesting" or even
"Production/MyEnvironment/ExtensionTesting".