### PR TITLE
[TASK] Run tests with PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
                     - "7.3"
                     - "7.4"
                     - "8.0"
+                    - "8.1"
                 composer-versions:
                     - "v1"
                     - "v2"
@@ -51,6 +52,7 @@ jobs:
               run: composer test:php:lint
 
             - name: CGL
+              if: ${{ matrix.php-versions != '8.1' }}
               run: vendor/bin/php-cs-fixer fix --dry-run --verbose
 
             - name: Unit Tests


### PR DESCRIPTION
php-cs-fixer is not yet 8.1 compatible, but
linting and unit testing can be activated.