### PR TITLE
[TASK] More strict phpunit testing

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,24 +4,26 @@
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
+         convertDeprecationsToExceptions="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnWarning="true"
+         failOnRisky="true"
 >
-
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
 
     <testsuites>
         <testsuite name="installer-unit-tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
 
 </phpunit>


### PR DESCRIPTION
* Activate a couple of "fail more often" flags, and/or
  make them more explicit.
* Drop invalid coverage tag - it does not exist and
  phpunit mumbles with "Element 'coverage': This element
  is not expected."
* error_reporting default is E_ALL & ~E_DEPRECATED & ~E_STRICT.
  In general, we should strive for E_ALL error free tests:
  This helps to find issues with younger PHP versions more
  quickly.