### PR TITLE
adjust downloader return types for composer 2.3 compatibility (#132)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "netresearch/composer-installers": "*"
     },
     "require": {
-        "php": ">=7.0.0 <7.5",
+        "php": ">=7.1.0 <7.5",
         "composer-plugin-api": "^1.0.0 || ^2.0.0"
     },
     "conflict": {

--- a/src/Installer/Downloader/T3xDownloader2.php
+++ b/src/Installer/Downloader/T3xDownloader2.php
@@ -18,7 +18,9 @@ namespace TYPO3\CMS\Composer\Installer\Downloader;
 use Composer\Downloader\ArchiveDownloader;
 use Composer\Downloader\ChangeReportInterface;
 use Composer\Package\PackageInterface;
+use React\Promise\PromiseInterface;
 use TYPO3\CMS\Composer\Plugin\Util\T3xDownloaderUtility;
+use function React\Promise\resolve;
 
 /**
  * TYPO3 CMS Extension Downloader
@@ -26,18 +28,28 @@ use TYPO3\CMS\Composer\Plugin\Util\T3xDownloaderUtility;
  */
 class T3xDownloader2 extends ArchiveDownloader implements ChangeReportInterface
 {
+    // the method parameters are carefully typed
+    // composer <= 2.2 has no type annotations and runs with php 7.0+
+    // composer >= 2.3 has type annotations and runs with php 7.2+
+    // decreasing the strictness of the method signature is only allowed in php 7.2+
+    // but the parent class only has type annotations with composer 2.3 and that composer runs with php 7.2+
+    // so this should work in all composer versions that match their respective php version
+
     /**
      * {@inheritDoc}
+     * @noinspection PhpHierarchyChecksInspection
      */
-    protected function extract(PackageInterface $package, $file, $path)
+    protected function extract(PackageInterface $package, $file, $path): PromiseInterface
     {
         T3xDownloaderUtility::extract($package, $file, $path);
+        return resolve();
     }
 
     /**
      * {@inheritDoc}
+     * @noinspection PhpHierarchyChecksInspection
      */
-    public function getLocalChanges(PackageInterface $package, $path)
+    public function getLocalChanges(PackageInterface $package, $path): ?string
     {
         T3xDownloaderUtility::getLocalChanges($package, $path);
     }


### PR DESCRIPTION
The class in composer 2.3 now requires a Promise being returned.
This can simply be adjusted by still running synchronously
and then returning a resolved promise instantly.

The downside is that the new abstract class requires
the return type "?string", which is only possible in php 7.1,
so I had to increase the php version requirement.

I described more considerations in the php file itself.