### PR TITLE
[FEATURE] Allow overriding "web-dir" with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ document root should be located.
 *The default value* is `"public"`, which means a `"public"` directory at the
 same level as your root `composer.json`.
 
+You may define the `web-dir` also via the environment variable `TYPO3_PATH_ROOT`, which takes precedence over the `composer.json` option._
+
 ## Feedback / Bug reports / Contribution
 
 Bug reports, feature requests and pull requests are welcome in the GitHub

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ document root should be located.
 *The default value* is `"public"`, which means a `"public"` directory at the
 same level as your root `composer.json`.
 
+If the environment variable `TYPO3_COMPOSER_WEB_DIR` is set when running `composer install/update/dumpautoload`,
+it takes precedence over the `web-dir` option defined in the `composer.json` file.
+
 ## Feedback / Bug reports / Contribution
 
 Bug reports, feature requests and pull requests are welcome in the GitHub

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ document root should be located.
 *The default value* is `"public"`, which means a `"public"` directory at the
 same level as your root `composer.json`.
 
-You may define the `web-dir` also via the environment variable `TYPO3_PATH_ROOT`, which takes precedence over the `composer.json` option._
-
 ## Feedback / Bug reports / Contribution
 
 Bug reports, feature requests and pull requests are welcome in the GitHub

--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -226,6 +226,9 @@ class Config
             $io->warning('Changing root-dir is not supported any more. TYPO3 root-dir will always be the same as web-dir');
         }
         unset($rootPackageExtraConfig['typo3/cms']['root-dir'], $rootPackageExtraConfig['typo3/cms']['app-dir']);
+        if (getenv('TYPO3_COMPOSER_WEB_DIR') !== false) {
+            $rootPackageExtraConfig['typo3/cms']['web-dir'] = getenv('TYPO3_COMPOSER_WEB_DIR');
+        }
         $fileSystem = new Filesystem();
         $config = new static('/fake/root');
         $config->merge($rootPackageExtraConfig);

--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -73,10 +73,6 @@ class Config
                 $this->config[$key] = $val;
             }
         }
-        // if web-dir is defined via TYPO3_PATH_ROOT already, stick to it
-        if (getenv('TYPO3_PATH_ROOT')) {
-            $this->config['web-dir'] = getenv('TYPO3_PATH_ROOT');
-        }
     }
 
     /**

--- a/src/Plugin/Config.php
+++ b/src/Plugin/Config.php
@@ -73,6 +73,10 @@ class Config
                 $this->config[$key] = $val;
             }
         }
+        // if web-dir is defined via TYPO3_PATH_ROOT already, stick to it
+        if (getenv('TYPO3_PATH_ROOT')) {
+            $this->config['web-dir'] = getenv('TYPO3_PATH_ROOT');
+        }
     }
 
     /**


### PR DESCRIPTION
For some edge cases it might be useful to override, what is defined
in the root composer.json file for the web-dir, to allow
different web directories for different environments, without
changing the root composer.json

Resolves: #145